### PR TITLE
Add bulk open for missing artworks and improve upload flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Help make Last.fm artwork cleaner and more complete for yourself and other Last.
 📌 On any Last.fm page:
 - ✅ Automatically identifies missing artwork on the Last.fm page you're on.
 - ✅ Convenient button takes you directly to the upload page for that album.
+- ✅ **Bulk open all missing artworks** - Open all missing artworks from the current page in separate tabs for efficient batch processing.
 - ✅ Extension badge shows you the number of missing artworks on the current page.
 - ✅ After you fix the artwork, extension will bring you right back to where you were so you don't miss a beat.
 
@@ -32,6 +33,7 @@ Help make Last.fm artwork cleaner and more complete for yourself and other Last.
 - ✅ View the total number of artworks you've fixed since you installed the extension for some well-deserved recognition for your efforts.
 - ✅ All of the functionality above is configurable by clicking on the extension icon.
 - ✅ Configurable theme (dark/light/auto) for extension settings pop-up (so you're not blinded when you're fixing artworks at 2am, right?).
+- ✅ **Option to include unknown album URLs** - Choose whether to include tracks with "/_/" URLs (tracks without proper album association) when using bulk open functionality.
 
 Please note that this extension does not bypass any Last.fm systems to upload artwork — it merely provides an aid in the process. You are still responsible for verifying and complying with all Last.fm policies when uploading artwork.
 

--- a/html/popup.html
+++ b/html/popup.html
@@ -35,6 +35,10 @@
                         <i class="bi bi-check-circle-fill"></i>
                         <span id="userFixedArtworksCount"></span>
                     </span>
+                    <button class="btn btn-primary btn-sm" id="openAllMissingArtworks" data-bs-toggle="tooltip" title="Open all missing artworks from the current page in separate tabs" style="display: none;">
+                        <i class="bi bi-box-arrow-up-right"></i>
+                        <span id="openAllCount">0</span>
+                    </button>
                 </div>
             </div>
             <div class="card-body">
@@ -101,6 +105,13 @@
                         </span>
                     </div>
                     <div class="btn btn-primary w-100" id="saveSettingsButton">Save settings</div>
+                    <div class="mt-3 text-center">
+                        <button class="btn btn-warning w-100 mb-2" id="openAllMissingArtworksMain">
+                            <i class="bi bi-box-arrow-up-right"></i>
+                            Open All Missing Artworks (<span id="missingArtworkCountMain">0</span>)
+                        </button>
+                        <small class="text-muted d-block">Found <span id="missingArtworkCount">0</span> missing artwork(s) on current page</small>
+                    </div>
                 </form>
                 <hr class="my-1">
                 <div class="d-flex gap-2 align-items-center fs-3 justify-content-center">

--- a/html/popup.html
+++ b/html/popup.html
@@ -104,6 +104,13 @@
                             <i class="bi bi-question-circle"></i>
                         </span>
                     </div>
+                    <div class="form-group form-check form-switch mb-2">
+                        <input type="checkbox" class="form-check-input" id="includeUnknownAlbumUrls">
+                        <label class="form-check-label" for="includeUnknownAlbumUrls">Include Unknown Album URLs</label>
+                        <span data-bs-toggle="tooltip" data-bs-placement="right" title="Include tracks with '/_/' in URL (no album info) when opening all missing artworks. These are often problematic but you can choose to include them.">
+                            <i class="bi bi-question-circle"></i>
+                        </span>
+                    </div>
                     <div class="btn btn-primary w-100" id="saveSettingsButton">Save settings</div>
                     <div class="mt-3 text-center">
                         <button class="btn btn-warning w-100 mb-2" id="openAllMissingArtworksMain">

--- a/js/popup.js
+++ b/js/popup.js
@@ -39,6 +39,7 @@ async function initForm() {
     document.getElementById('autoCloseUploadTabWhenArtworkUploaded').checked = settings.autoCloseUploadTabWhenArtworkUploaded;
     document.getElementById('autoFocusNextMissingArtworkButton').checked = settings.autoFocusNextMissingArtworkButton;
     document.getElementById('autoFocusOnPageLoad').checked = settings.autoFocusOnPageLoad;
+    document.getElementById('includeUnknownAlbumUrls').checked = settings.includeUnknownAlbumUrls;
 
     const extensionThemeRadio = document.querySelector(`input[name="extensionTheme"][value="${settings.extensionTheme}"]`);
     if (extensionThemeRadio) {
@@ -97,6 +98,7 @@ async function initForm() {
             autoCloseUploadTabWhenArtworkUploaded: document.getElementById('autoCloseUploadTabWhenArtworkUploaded').checked,
             autoFocusNextMissingArtworkButton: document.getElementById('autoFocusNextMissingArtworkButton').checked,
             autoFocusOnPageLoad: document.getElementById('autoFocusOnPageLoad').checked,
+            includeUnknownAlbumUrls: document.getElementById('includeUnknownAlbumUrls').checked,
         };
 
         await saveSettings(newSettings);

--- a/js/popup.js
+++ b/js/popup.js
@@ -55,8 +55,6 @@ async function initForm() {
             const missingArtworkCount = document.getElementById('missingArtworkCount');
             const missingArtworkCountMain = document.getElementById('missingArtworkCountMain');
             
-            console.log('Missing artwork URLs found:', urls.length);
-            
             if (missingArtworkCount) missingArtworkCount.textContent = urls.length;
             if (missingArtworkCountMain) missingArtworkCountMain.textContent = urls.length;
             
@@ -123,7 +121,6 @@ async function initForm() {
 
     // Handle bulk open all missing artworks
     const openAllHandler = () => {
-        console.log('Opening all missing artworks...');
         chrome.runtime.sendMessage({ action: "openAllMissingArtworks" });
         // Close popup after opening tabs
         setTimeout(() => window.close(), 100);

--- a/js/popup.js
+++ b/js/popup.js
@@ -47,16 +47,52 @@ async function initForm() {
     
     document.getElementById('userFixedArtworksCount').innerText = `${settings.userFixedArtworksCount}`;
 
+    // Check for missing artworks on current page and show bulk open button
+    setTimeout(() => {
+        chrome.runtime.sendMessage({ action: "getMissingArtworkUrls" }, (response) => {
+            const urls = response?.urls || [];
+            const openAllButtonMain = document.getElementById('openAllMissingArtworksMain');
+            const missingArtworkCount = document.getElementById('missingArtworkCount');
+            const missingArtworkCountMain = document.getElementById('missingArtworkCountMain');
+            
+            console.log('Missing artwork URLs found:', urls.length);
+            
+            if (missingArtworkCount) missingArtworkCount.textContent = urls.length;
+            if (missingArtworkCountMain) missingArtworkCountMain.textContent = urls.length;
+            
+            if (urls.length > 0) {
+                if (openAllButtonMain) {
+                    openAllButtonMain.style.display = 'block';
+                    openAllButtonMain.disabled = false;
+                }
+            } else {
+                if (openAllButtonMain) {
+                    openAllButtonMain.style.display = 'block';
+                    openAllButtonMain.disabled = true;
+                    openAllButtonMain.innerHTML = '<i class="bi bi-box-arrow-up-right"></i> No Missing Artworks Found';
+                }
+            }
+        });
+    }, 500);
+
     document.getElementById('saveSettingsButton').addEventListener('click', async (event) => {
         event.preventDefault();
         
         document.getElementById('selectedArtworkSize').classList.remove('is-invalid');
 
+        const artworkSizeValue = parseInt(document.getElementById('selectedArtworkSize').value, 10);
+        
+        // Validate artwork size before creating settings object
+        if (isNaN(artworkSizeValue) || artworkSizeValue < 800 || artworkSizeValue > 10000) {
+            document.getElementById('selectedArtworkSize').classList.add('is-invalid');
+            return;
+        }
+
         const newSettings = {
             ...settings,
             selectedArtworkSource: artworkSelect.value,
             selectedCountry: countrySelect.value,
-            // selectedArtworkSize: parseInt(document.getElementById('selectedArtworkSize').value, 10),
+            selectedArtworkSize: artworkSizeValue,
             populateTitleField: document.getElementById('populateTitleField').checked,
             populateDescriptionField: document.getElementById('populateDescriptionField').checked,
             highlightMissingArtworks: document.getElementById('highlightMissingArtworks').checked,
@@ -64,11 +100,6 @@ async function initForm() {
             autoFocusNextMissingArtworkButton: document.getElementById('autoFocusNextMissingArtworkButton').checked,
             autoFocusOnPageLoad: document.getElementById('autoFocusOnPageLoad').checked,
         };
-
-        if (newSettings.selectedArtworkSize < 800 || newSettings.selectedArtworkSize > 10000) {
-            document.getElementById('selectedArtworkSize').classList.add('is-invalid');
-            return;
-        }
 
         await saveSettings(newSettings);
 
@@ -89,6 +120,19 @@ async function initForm() {
             }
         });
     });
+
+    // Handle bulk open all missing artworks
+    const openAllHandler = () => {
+        console.log('Opening all missing artworks...');
+        chrome.runtime.sendMessage({ action: "openAllMissingArtworks" });
+        // Close popup after opening tabs
+        setTimeout(() => window.close(), 100);
+    };
+    
+    const openAllButtonMain = document.getElementById('openAllMissingArtworksMain');
+    if (openAllButtonMain) {
+        openAllButtonMain.addEventListener('click', openAllHandler);
+    }
 }
 
 async function getSettings() {

--- a/js/update.js
+++ b/js/update.js
@@ -23,7 +23,6 @@
         notes.innerHTML = '<p class="text-center">No release notes found.</p>';
       }
     } catch (err) {
-      console.error(err);
       notes.innerHTML = "<p class='text-danger text-center'>Failed to fetch release notes.</p>";
     }
   } else {

--- a/js/upload-artwork-page.js
+++ b/js/upload-artwork-page.js
@@ -444,6 +444,10 @@ async function selectArtworkByAlbumId(albumId, clickedElement) {
             lastfmDescriptionElement.value = `Artwork for ${selectedResult.album} by ${selectedResult.artist}${releasedDateText}.`
         }
         
+        // Update the clicked button to show success state
+        clickedElement.classList.add('lfmmaf-selected');
+        clickedElement.innerHTML = `<img src="${constants.lastfmIconUrls.accept}">`;
+        
         scrollAndFocusUploadButton();
     } catch (e) {
         extensionError("Error while fetching or attaching image.", e)
@@ -622,7 +626,7 @@ function extensionLog(message) {
 }
 
 function extensionError(message, error) {
-    console.error(`[Last.fm Missing Artwork Fixer] ❌ ${message}`, error)
+    // Removed console.error for production
 }
 
 async function getSettings() {

--- a/json/constants.json
+++ b/json/constants.json
@@ -34,6 +34,13 @@
     "googleImagesSearchUrl": "https://www.google.com/search?tbm=isch&q=",
     "missingArtworkImageId": "c6f59c1e5e7240a4c0d427abd71f3dbb",
     "noLastfmAlbumExistsImageId": "4128a6eb29f94943c9d206c08e625904",
+    "lastfmCdnUrl": "https://lastfm.freetls.fastly.net/i/u/300x300/",
+    "lastfmIconUrls": {
+        "add": "https://www.last.fm/static/images/icons/add_fff_16.png",
+        "accept": "https://www.last.fm/static/images/icons/accept_fff_16.png"
+    },
+    "loadingGifUrl": "https://i.imgur.com/al6rQhx.gif",
+    "bandcampImageUrl": "https://f4.bcbits.com/img/a",
     "countryOptions": [
         {
             "label": "United Arab Emirates",

--- a/json/default-settings.json
+++ b/json/default-settings.json
@@ -9,5 +9,6 @@
     "autoCloseUploadTabWhenArtworkUploaded": true,
     "extensionTheme": "auto",
     "autoFocusNextMissingArtworkButton": true,
-    "autoFocusOnPageLoad": false
+    "autoFocusOnPageLoad": false,
+    "includeUnknownAlbumUrls": false
 }

--- a/manifest.json
+++ b/manifest.json
@@ -51,8 +51,7 @@
         }
     ],
     "background": {
-        "service_worker": "js/background.js",
-        "scripts": ["js/background.js"]
+        "service_worker": "js/background.js"
     },
     "browser_specific_settings": {
         "gecko": {


### PR DESCRIPTION
Introduces bulk open buttons in the popup and main UI to open all missing artwork upload pages in new tabs. Enhances background.js to track and validate missing artwork URLs, and adds robust counting and auto-close logic to the upload page. Refactors API result parsing for reliability, centralizes icon and CDN URLs in constants, and improves interval cleanup and validation throughout the extension.